### PR TITLE
Make agencyCode and siteNumber required parameters for

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
                             <goal>start</goal>
                         </goals>
                         <configuration>
-                            <registry>cidasdpdasartip.cr.usgs.gov:8446</registry>
+                            <registry>cidasdpdasartip.cr.usgs.gov:8447</registry>
                             <showLogs>true</showLogs>
                             <images>
                                 <image>

--- a/src/main/java/gov/usgs/wma/mlrlegacy/Controller.java
+++ b/src/main/java/gov/usgs/wma/mlrlegacy/Controller.java
@@ -37,8 +37,8 @@ public class Controller {
 
 	@GetMapping()
 	public List<MonitoringLocation> getMonitoringLocations(
-		@RequestParam(name = AGENCY_CODE, required = false) String agencyCode,
-		@RequestParam(name = SITE_NUMBER, required = false) String siteNumber) {
+		@RequestParam(name = AGENCY_CODE) String agencyCode,
+		@RequestParam(name = SITE_NUMBER) String siteNumber) {
 		Map<String, Object> params = new HashMap<>();
 		if (null != agencyCode) {
 			params.put(AGENCY_CODE, agencyCode);

--- a/src/test/java/gov/usgs/wma/mlrlegacy/ControllerTest.java
+++ b/src/test/java/gov/usgs/wma/mlrlegacy/ControllerTest.java
@@ -33,6 +33,8 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import gov.usgs.wma.mlrlegacy.db.BaseIT;
 import springfox.documentation.spi.service.contexts.SecurityContext;
@@ -58,26 +60,26 @@ public class ControllerTest {
 	public void givenReturnData_whenGetByMap_thenReturnList() throws Exception {
 		List<MonitoringLocation> mlList = new ArrayList<>();
 		MonitoringLocation mlOne = new MonitoringLocation();
-		MonitoringLocation mlTwo = new MonitoringLocation();
 
 		mlOne.setId(BigInteger.ONE);
 		mlOne.setAgencyCode(BaseIT.DEFAULT_AGENCY_CODE);
 		mlOne.setSiteNumber("987654321");
-		mlTwo.setId(BigInteger.TEN);
-		mlTwo.setAgencyCode(BaseIT.DEFAULT_AGENCY_CODE);
-		mlTwo.setSiteNumber("11112222");
 
 		mlList.add(mlOne);
-		mlList.add(mlTwo);
 		Map<String, Object> params = new HashMap<>();
+		params.put(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
+		params.put(Controller.SITE_NUMBER, "987654321");
 
+		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<String, String>();
+		cruParams.set(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
+		cruParams.set(Controller.SITE_NUMBER, "987654321");
+		
 		given(dao.getByMap(params)).willReturn(mlList);
 
-		mvc.perform(get("/monitoringLocations"))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.length()", is(equalTo(2))))
-				.andExpect(jsonPath("$[0].id", is(equalTo(1))))
-				.andExpect(jsonPath("$[1].id", is(equalTo(10))));
+		mvc.perform(get("/monitoringLocations").params(cruParams))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.length()", is(equalTo(1))))
+			.andExpect(jsonPath("$[0].id", is(equalTo(1))));
 	}
 
 	@Test
@@ -93,10 +95,15 @@ public class ControllerTest {
 
 		Map<String, Object> params = new HashMap<>();
 		params.put(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
+		params.put(Controller.SITE_NUMBER, BaseIT.NULL_SITE_NUMBER);
+		
+		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<String, String>();
+		cruParams.set(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
+		cruParams.set(Controller.SITE_NUMBER, BaseIT.NULL_SITE_NUMBER);
 
 		given(dao.getByMap(params)).willReturn(mlList);
 
-		mvc.perform(get("/monitoringLocations").param(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE))
+		mvc.perform(get("/monitoringLocations").params(cruParams))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.length()", is(equalTo(1))))
 				.andExpect(jsonPath("$[0].id", is(equalTo(1))));
@@ -115,10 +122,15 @@ public class ControllerTest {
 
 		Map<String, Object> params = new HashMap<>();
 		params.put(Controller.SITE_NUMBER, "987654321");
+		params.put(Controller.AGENCY_CODE, BaseIT.NULL_AGENCY_CODE);
+		
+		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<String, String>();
+		cruParams.set(Controller.AGENCY_CODE, BaseIT.NULL_AGENCY_CODE);
+		cruParams.set(Controller.SITE_NUMBER, "987654321");
 
 		given(dao.getByMap(params)).willReturn(mlList);
 
-		mvc.perform(get("/monitoringLocations").param(Controller.SITE_NUMBER, "987654321"))
+		mvc.perform(get("/monitoringLocations").params(cruParams))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.length()", is(equalTo(1))))
 				.andExpect(jsonPath("$[0].id", is(equalTo(1))));

--- a/src/test/java/gov/usgs/wma/mlrlegacy/ControllerTest.java
+++ b/src/test/java/gov/usgs/wma/mlrlegacy/ControllerTest.java
@@ -70,7 +70,7 @@ public class ControllerTest {
 		params.put(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
 		params.put(Controller.SITE_NUMBER, "987654321");
 
-		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<String, String>();
+		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<>();
 		cruParams.set(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
 		cruParams.set(Controller.SITE_NUMBER, "987654321");
 		
@@ -80,60 +80,6 @@ public class ControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.length()", is(equalTo(1))))
 			.andExpect(jsonPath("$[0].id", is(equalTo(1))));
-	}
-
-	@Test
-	public void givenReturnData_whenGetByAgencyCode_theReturnList() throws Exception {
-		List<MonitoringLocation> mlList = new ArrayList<>();
-		MonitoringLocation mlOne = new MonitoringLocation();
-
-		mlOne.setId(BigInteger.ONE);
-		mlOne.setAgencyCode(BaseIT.DEFAULT_AGENCY_CODE);
-		mlOne.setSiteNumber("987654321");
-
-		mlList.add(mlOne);
-
-		Map<String, Object> params = new HashMap<>();
-		params.put(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
-		params.put(Controller.SITE_NUMBER, BaseIT.NULL_SITE_NUMBER);
-		
-		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<String, String>();
-		cruParams.set(Controller.AGENCY_CODE, BaseIT.DEFAULT_AGENCY_CODE);
-		cruParams.set(Controller.SITE_NUMBER, BaseIT.NULL_SITE_NUMBER);
-
-		given(dao.getByMap(params)).willReturn(mlList);
-
-		mvc.perform(get("/monitoringLocations").params(cruParams))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.length()", is(equalTo(1))))
-				.andExpect(jsonPath("$[0].id", is(equalTo(1))));
-	}
-
-	@Test
-	public void givenReturnData_whenGetBySiteNumber_theReturnList() throws Exception {
-		List<MonitoringLocation> mlList = new ArrayList<>();
-		MonitoringLocation mlOne = new MonitoringLocation();
-
-		mlOne.setId(BigInteger.ONE);
-		mlOne.setAgencyCode(BaseIT.DEFAULT_AGENCY_CODE);
-		mlOne.setSiteNumber("987654321");
-
-		mlList.add(mlOne);
-
-		Map<String, Object> params = new HashMap<>();
-		params.put(Controller.SITE_NUMBER, "987654321");
-		params.put(Controller.AGENCY_CODE, BaseIT.NULL_AGENCY_CODE);
-		
-		MultiValueMap<String, String> cruParams = new LinkedMultiValueMap<String, String>();
-		cruParams.set(Controller.AGENCY_CODE, BaseIT.NULL_AGENCY_CODE);
-		cruParams.set(Controller.SITE_NUMBER, "987654321");
-
-		given(dao.getByMap(params)).willReturn(mlList);
-
-		mvc.perform(get("/monitoringLocations").params(cruParams))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.length()", is(equalTo(1))))
-				.andExpect(jsonPath("$[0].id", is(equalTo(1))));
 	}
 
 	@Test

--- a/src/test/java/gov/usgs/wma/mlrlegacy/db/BaseIT.java
+++ b/src/test/java/gov/usgs/wma/mlrlegacy/db/BaseIT.java
@@ -43,6 +43,8 @@ public abstract class BaseIT {
 	public static final BigInteger ONE_MILLION = BigInteger.valueOf(1000000);
 	public static final String DEFAULT_AGENCY_CODE = "USGS ";
 	public static final String DEFAULT_SITE_NUMBER = "123456789012345";
+	public static final String NULL_AGENCY_CODE = "";
+	public static final String NULL_SITE_NUMBER = "";
 	public static final String DEFAULT_CREATED_DATE_M = "2017-08-24 09:15";
 	public static final String DEFAULT_CREATED_DATE_S = DEFAULT_CREATED_DATE_M + ":23";
 	public static final String DEFAULT_CREATED_BY = "site_cn ";

--- a/src/test/java/gov/usgs/wma/mlrlegacy/db/BaseIT.java
+++ b/src/test/java/gov/usgs/wma/mlrlegacy/db/BaseIT.java
@@ -43,8 +43,6 @@ public abstract class BaseIT {
 	public static final BigInteger ONE_MILLION = BigInteger.valueOf(1000000);
 	public static final String DEFAULT_AGENCY_CODE = "USGS ";
 	public static final String DEFAULT_SITE_NUMBER = "123456789012345";
-	public static final String NULL_AGENCY_CODE = "";
-	public static final String NULL_SITE_NUMBER = "";
 	public static final String DEFAULT_CREATED_DATE_M = "2017-08-24 09:15";
 	public static final String DEFAULT_CREATED_DATE_S = DEFAULT_CREATED_DATE_M + ":23";
 	public static final String DEFAULT_CREATED_BY = "site_cn ";

--- a/src/test/java/gov/usgs/wma/mlrlegacy/db/ControllerRIT.java
+++ b/src/test/java/gov/usgs/wma/mlrlegacy/db/ControllerRIT.java
@@ -18,42 +18,11 @@ public class ControllerRIT extends BaseControllerIT {
 	public void getMonitoringLocationsFound() throws Exception {
 		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations", String.class);
 
-		assertEquals(200, responseEntity.getStatusCodeValue());
-		JSONAssert.assertEquals("[" + getExpectedReadJson("oneMillion.json") + "]", responseEntity.getBody(), JSONCompareMode.STRICT);
+		assertEquals(400, responseEntity.getStatusCodeValue());
+		//JSONAssert.assertEquals("[" + getExpectedReadJson("oneMillion.json") + "]", responseEntity.getBody(), JSONCompareMode.STRICT);
 	}
 	
-	@Test
-	public void getMonitoringLocationsByAgencyCodeFound() throws Exception {
-		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations?agencyCode=USGS", String.class);
 
-		assertEquals(200, responseEntity.getStatusCodeValue());
-		JSONAssert.assertEquals("[" + getExpectedReadJson("oneMillion.json") + "]", responseEntity.getBody(), JSONCompareMode.STRICT);
-	}
-	
-	@Test
-	public void getMonitoringLocationsByAgencyCodeNotFound() throws Exception {
-		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations?agencyCode=USEPA", String.class);
-
-		assertEquals(200, responseEntity.getStatusCodeValue());
-		JSONAssert.assertEquals("[]", responseEntity.getBody(), JSONCompareMode.STRICT);
-	}
-	
-	@Test
-	public void getMonitoringLocationsBySiteNumberFound() throws Exception {
-		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations?siteNumber=123456789012345", String.class);
-
-		assertEquals(200, responseEntity.getStatusCodeValue());
-		JSONAssert.assertEquals("[" + getExpectedReadJson("oneMillion.json") + "]", responseEntity.getBody(), JSONCompareMode.STRICT);
-	}
-	
-	@Test
-	public void getMonitoringLocationsBySiteNumberNotFound() throws Exception {
-		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations?siteNumber=123456789012349", String.class);
-
-		assertEquals(200, responseEntity.getStatusCodeValue());
-		JSONAssert.assertEquals("[]", responseEntity.getBody(), JSONCompareMode.STRICT);
-	}
-	
 	@Test
 	public void getMonitoringLocationsByAgencyCodeAndSiteNumberFound() throws Exception {
 		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations?agencyCode=USGS&siteNumber=123456789012345", String.class);

--- a/src/test/java/gov/usgs/wma/mlrlegacy/db/ControllerRIT.java
+++ b/src/test/java/gov/usgs/wma/mlrlegacy/db/ControllerRIT.java
@@ -15,11 +15,10 @@ import com.github.springtestdbunit.annotation.DatabaseSetup;
 public class ControllerRIT extends BaseControllerIT {
 
 	@Test
-	public void getMonitoringLocationsFound() throws Exception {
+	public void getMonitoringLocationsNoAgencyCodeNoSiteNumberInvalidRequest() throws Exception {
 		ResponseEntity<String> responseEntity = restTemplate.getForEntity("/monitoringLocations", String.class);
 
 		assertEquals(400, responseEntity.getStatusCodeValue());
-		//JSONAssert.assertEquals("[" + getExpectedReadJson("oneMillion.json") + "]", responseEntity.getBody(), JSONCompareMode.STRICT);
 	}
 	
 


### PR DESCRIPTION
monitoringLocations endpoint to avoid bringing down app by requesting
entire sitefile.